### PR TITLE
Allows to alias a specific tables to structs

### DIFF
--- a/sqlstruct_test.go
+++ b/sqlstruct_test.go
@@ -20,6 +20,11 @@ type testType struct {
 	EmbeddedType
 }
 
+type testType2 struct {
+	FieldA   string `sql:"field_a"`
+	FieldSec string `sql:"field_sec"`
+}
+
 // testRows is a mock version of sql.Rows which can only scan strings
 type testRows struct {
 	columns []string
@@ -62,6 +67,26 @@ func TestColumns(t *testing.T) {
 	}
 }
 
+func TestColumnsAliased(t *testing.T) {
+	var t1 testType
+	var t2 testType2
+
+	expected := "t1.field_a AS t1_field_a, t1.field_c AS t1_field_c, "
+	expected += "t1.field_d AS t1_field_d, t1.field_e AS t1_field_e"
+	actual := ColumnsAliased(t1, "t1")
+
+	if expected != actual {
+		t.Errorf("Expected %q got %q", expected, actual)
+	}
+
+	expected = "t2.field_a AS t2_field_a, t2.field_sec AS t2_field_sec"
+	actual = ColumnsAliased(t2, "t2")
+
+	if expected != actual {
+		t.Errorf("Expected %q got %q", expected, actual)
+	}
+}
+
 func TestScan(t *testing.T) {
 	rows := testRows{}
 	rows.addValue("field_a", "a")
@@ -80,5 +105,39 @@ func TestScan(t *testing.T) {
 
 	if r != e {
 		t.Errorf("expected %q got %q", e, r)
+	}
+}
+
+func TestScanAliased(t *testing.T) {
+	rows := testRows{}
+	rows.addValue("t1_field_a", "a")
+	rows.addValue("t1_field_b", "b")
+	rows.addValue("t1_field_c", "c")
+	rows.addValue("t1_field_d", "d")
+	rows.addValue("t1_field_e", "e")
+	rows.addValue("t2_field_a", "a2")
+	rows.addValue("t2_field_sec", "sec")
+
+	expected := testType{"a", "", "c", "d", EmbeddedType{"e"}}
+	var actual testType
+	err := ScanAliased(&actual, rows, "t1")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if expected != actual {
+		t.Errorf("expected %q got %q", expected, actual)
+	}
+
+	expected2 := testType2{"a2", "sec"}
+	var actual2 testType2
+
+	err = ScanAliased(&actual2, rows, "t2")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if expected2 != actual2 {
+		t.Errorf("expected %q got %q", expected2, actual2)
 	}
 }


### PR DESCRIPTION
Its often useful to have joins in a query and this allows to scan separate table data into a separate struct.
See the example bellow:

Sql used with MySQL driver

``` sql
CREATE TABLE IF NOT EXISTS address (
  id INTEGER NOT NULL AUTO_INCREMENT,
  address VARCHAR(512) NOT NULL,
  city VARCHAR(32) NOT NULL,
  PRIMARY KEY (id)
) ENGINE=InnoDB;

INSERT INTO address (address, city) VALUES
('Plento 34', 'Vilnius');

CREATE TABLE IF NOT EXISTS users (
  id INTEGER NOT NULL AUTO_INCREMENT,
  username VARCHAR(32) NOT NULL,
  name VARCHAR(64) NOT NULL,
  address VARCHAR(256) NOT NULL,
  address_id INTEGER NOT NULL,
  PRIMARY KEY (id),
  UNIQUE KEY address_id(address_id),
  CONSTRAINT fk_user_address FOREIGN KEY (address_id) REFERENCES address(id)
) ENGINE=InnoDB;

INSERT INTO users (username, name, address, address_id) VALUES
('gedi', 'Gedas', 'gediminas.morkevicius@gmail.com', 1);
```

And go code to see it in action:

``` go
package main

import "github.com/kisielk/sqlstruct"
import "database/sql"
import _ "github.com/go-sql-driver/mysql"
import "fmt"
import "log"

type User struct {
    Id int `sql:"id"`
    Username string `sql:"username"`
    Email string `sql:"address"`
    Name string `sql:"name"`
    HomeAddress *Address `sql:"-"`
}

type Address struct {
    Id int `sql:"id"`
    City string `sql:"city"`
    Street string `sql:"address"`
}

func main() {
    db, err := sql.Open("mysql", "root:nimda@/test")
    if err != nil {
        log.Fatal(err)
    }
    defer db.Close()

    user := new(User)
    address := new(Address)
    sql := `
SELECT %s, %s FROM users AS u
INNER JOIN address AS a ON a.id = u.address_id
WHERE u.username = ?
`
    sql = fmt.Sprintf(sql, sqlstruct.AliasedColumns(*user, "u"), sqlstruct.AliasedColumns(*address, "a"))
    rows, err := db.Query(sql, "gedi")
    if err != nil {
        log.Fatal(err)
    }
    defer rows.Close()
    if rows.Next() {
        err = sqlstruct.AliasedScan(user, rows, "u")
        if err != nil {
            log.Fatal(err)
        }
        err = sqlstruct.AliasedScan(address, rows, "a")
        if err != nil {
            log.Fatal(err)
        }
        user.HomeAddress = address
    }
    fmt.Printf("user: %+v and his home address: %+v", *user, *user.HomeAddress)
}
```

Maybe the names **AliasedScan** and **AliasedColumns** could be renamed into something lighter like **ScanA** since it would go to public interface.
