### PR TITLE
Add sqlstruct.NameMapper

### DIFF
--- a/sqlstruct_test.go
+++ b/sqlstruct_test.go
@@ -141,3 +141,21 @@ func TestScanAliased(t *testing.T) {
 		t.Errorf("expected %q got %q", expected2, actual2)
 	}
 }
+
+func TestToSnakeCase(t *testing.T) {
+	var s string
+	s = ToSnakeCase("FirstName")
+	if "first_name" != s {
+		t.Errorf("expected first_name got %q", s)
+	}
+
+	s = ToSnakeCase("First")
+	if "first" != s {
+		t.Errorf("expected first got %q", s)
+	}
+
+	s = ToSnakeCase("firstName")
+	if "first_name" != s {
+		t.Errorf("expected first_name got %q", s)
+	}
+}


### PR DESCRIPTION
I prefer database tables with underscore-separated (i.e. "snakecase") words. The default behavior in sqlstruct requires me to alias every multi-word struct field (e.g. FirstName string `sql:"first_name"`). This pull request preserves the existing behavior of sqlstruct, but allows that functionality to be overridden by altering sqlstruct.NameMapper. The default NameMapper is strings.ToLower, which is how the old behavior is preserved. I've also added sqlstruct.ToSnakeCase to easily allow snake casing without requiring the user to implement the function at the application level.