### PR TITLE
Configurable `tagName` value

### DIFF
--- a/sqlstruct.go
+++ b/sqlstruct.go
@@ -108,8 +108,8 @@ var NameMapper = strings.ToLower
 var finfos map[reflect.Type]fieldInfo
 var finfoLock sync.RWMutex
 
-// tagName is the name of the tag to use on struct fields
-const tagName = "sql"
+// TagName is the name of the tag to use on struct fields
+var TagName = "sql"
 
 // fieldInfo is a mapping of field tag values to their indices
 type fieldInfo map[string][]int
@@ -140,7 +140,7 @@ func getFieldInfo(typ reflect.Type) fieldInfo {
 	n := typ.NumField()
 	for i := 0; i < n; i++ {
 		f := typ.Field(i)
-		tag := f.Tag.Get(tagName)
+		tag := f.Tag.Get(TagName)
 
 		// Skip unexported fields or fields marked with "-"
 		if f.PkgPath != "" || tag == "-" {


### PR DESCRIPTION
It would be nice to be able to set the name of the struct tag used when parsing the column name from the struct. This pull request does this in the most simple way I could think of -- by changing the `const tagName` to `var TagName`.

I'm working on a "Resource" struct that provides the bridge between my database rows and my API response -- and I've already got a couple of tags on my struct fields, one called `json`, for `endcoding/json`, and one called `db` for jmoiron/sqlx. Ideally, I'd like to re-use this `db` tag as they follow the same rules as your library, which I am only using for the handy `Columns()` function.

Thank you for considering this humble pull request.