### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ go:
   - tip
 jobs:
  exclude:
-  go: 1.2
-  arch: ppc64le
+  - go: 1.2
+    arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 
 go:
   - 1.2
   - tip
+jobs:
+ exclude:
+  go: 1.2
+  arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ jobs:
  exclude:
   - go: 1.2
     arch: ppc64le
+  - go: 1.2
+    arch: amd64


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/sqlstruct

Please let me know if you need any further details? or if I am missing any.

Thank You !!