### PR TITLE
Fix codeblock on documentation

### DIFF
--- a/sqlstruct.go
+++ b/sqlstruct.go
@@ -52,10 +52,10 @@ by the same alias, using the ColumnsAliased and ScanAliased functions:
     var user User
     var address Address
     sql := `
-	SELECT %s, %s FROM users AS u
-	INNER JOIN address AS a ON a.id = u.address_id
-	WHERE u.username = ?
-	`
+    SELECT %s, %s FROM users AS u
+    INNER JOIN address AS a ON a.id = u.address_id
+    WHERE u.username = ?
+    `
     sql = fmt.Sprintf(sql, sqlstruct.ColumnsAliased(*user, "u"), sqlstruct.ColumnsAliased(*address, "a"))
     rows, err := db.Query(sql, "gedi")
     if err != nil {

--- a/sqlstruct.go
+++ b/sqlstruct.go
@@ -52,10 +52,10 @@ by the same alias, using the ColumnsAliased and ScanAliased functions:
     var user User
     var address Address
     sql := `
-SELECT %s, %s FROM users AS u
-INNER JOIN address AS a ON a.id = u.address_id
-WHERE u.username = ?
-`
+	SELECT %s, %s FROM users AS u
+	INNER JOIN address AS a ON a.id = u.address_id
+	WHERE u.username = ?
+	`
     sql = fmt.Sprintf(sql, sqlstruct.ColumnsAliased(*user, "u"), sqlstruct.ColumnsAliased(*address, "a"))
     rows, err := db.Query(sql, "gedi")
     if err != nil {


### PR DESCRIPTION
One example of this package's documentation is somehow broken:

![Screenshot from 2021-06-30 18-42-02](https://user-images.githubusercontent.com/15046792/123954750-f44d5380-d9d2-11eb-8166-a3eb6d3436f5.png)

so I would like to fix it by adding some indentation to the code block.